### PR TITLE
Configure allowed hosts via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# PranaV1.0
+# Prana
+
+Backend and frontend for the Prana project.
+
+## Environment variables
+
+The Django backend reads configuration from environment variables, typically via
+an `.env` file. Production settings look for the following variables:
+
+- `ALLOWED_HOSTS` - comma separated list of allowed hosts. If not provided,
+  development defaults of `localhost,127.0.0.1` are used.
+- `CORS_ALLOWED_ORIGINS` - comma separated list of origins allowed by CORS. The
+  default is `http://localhost:4200` for development.
+

--- a/apiRest/core/settings/production.py
+++ b/apiRest/core/settings/production.py
@@ -2,14 +2,17 @@ from .base import *
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool('DEBUG', default=False)
 
-ALLOWED_HOSTS = ['api.centroterapeuticoprana.com','centroterapeuticoprana.com','www.centroterapeuticoprana.com']
-CORS_ALLOWED_ORIGINS = [
-     #"http://localhost:4200",
-    #'http://216.196.63.221:4200',
-    'https://centroterapeuticoprana.com',
-    'http://centroterapeuticoprana.com',	
-    # !AcÃ¡ poner ip y puerto del frontÂ¡
-]
+# Hosts and origins can be supplied through environment variables.  When running
+# locally these fall back to common development values so the application works
+# without additional configuration.
+ALLOWED_HOSTS = env.list(
+    "ALLOWED_HOSTS",
+    default=["localhost", "127.0.0.1"],
+)
+CORS_ALLOWED_ORIGINS = env.list(
+    "CORS_ALLOWED_ORIGINS",
+    default=["http://localhost:4200"],
+)
 
 
 # Database


### PR DESCRIPTION
## Summary
- make ALLOWED_HOSTS and CORS_ALLOWED_ORIGINS configurable via environment variables
- explain variables in README

## Testing
- `python apiRest/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ad25d4110832bb51f06e04ae49666