### PR TITLE
Add logging to reminder command

### DIFF
--- a/apiRest/apps/appointments/management/commands/send_email_remainder.py
+++ b/apiRest/apps/appointments/management/commands/send_email_remainder.py
@@ -5,6 +5,9 @@ from django.utils.html import strip_tags
 from datetime import datetime, timedelta
 from apps.appointments.models import Appointment
 from django.core.mail import send_mail
+import logging
+
+logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     help = 'Send reminder emails to patients with appointments the next day'
 
@@ -25,7 +28,7 @@ class Command(BaseCommand):
             subject = 'Recordatorio de Turno - NO RESPONDER'
             from_email = 'no-reply@tudominio.com'
             to_email = [patient.user.email]
-            print("email enviado a" ,patient.user.email)
+            logger.info("email enviado a %s", patient.user.email)
             msg = EmailMultiAlternatives(subject, text_content, from_email, to_email)
             msg.attach_alternative(html_content, "text/html")
 

--- a/apiRest/core/settings/base.py
+++ b/apiRest/core/settings/base.py
@@ -175,3 +175,18 @@ EMAIL_USE_TLS = env('EMAIL_USE_TLS', default=True)
 EMAIL_HOST_USER = env('DEFAULT_FROM_EMAIL')
 EMAIL_HOST_USER = DEFAULT_FROM_EMAIL
 EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
+
+# Basic logging configuration
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
+}


### PR DESCRIPTION
## Summary
- switch to using logging in send_email_remainder command
- configure a basic logger in settings

## Testing
- `python -m py_compile apiRest/apps/appointments/management/commands/send_email_remainder.py`
- `python -m py_compile apiRest/core/settings/base.py`
- `python manage.py check --settings core.settings.local` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684ad2794484832ba83b6df53108623e