### PR TITLE
Update Prana frontend README

### DIFF
--- a/Frontend/Prana/README.md
+++ b/Frontend/Prana/README.md
@@ -2,6 +2,22 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 15.2.6.
 
+## Prerequisites
+
+- Node.js 16+ (Node 18 recommended)
+- Angular CLI 15.2.x (`npm install -g @angular/cli@15`)
+
+## Getting started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run tests:
+   ```bash
+   npm test
+   ```
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
@@ -21,6 +37,14 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 ## Running end-to-end tests
 
 Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+
+## Folder structure
+
+- `src/app` – Angular modules, components and services
+- `src/assets` – static assets
+- `src/environments` – environment configurations
+- `angular.json` – workspace and build settings
+- `package.json` – npm scripts and dependencies
 
 ## Further help
 


### PR DESCRIPTION
## Summary
- expand Prana README with prerequisites and usage info

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684ad58a5530832b85ac9001a14c09a3