### PR TITLE
Add Angular production environment

### DIFF
--- a/Frontend/Prana/angular.json
+++ b/Frontend/Prana/angular.json
@@ -35,6 +35,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/enviroments/environment.ts",
+                  "with": "src/enviroments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/Frontend/Prana/src/enviroments/environment.prod.ts
+++ b/Frontend/Prana/src/enviroments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  api_Url: 'https://api.centroterapeuticoprana.com/',
+};


### PR DESCRIPTION
## Summary
- add production environment configuration file
- reference the prod file in angular.json during production builds

## Testing
- `npm run build` *(fails: ng not found)*
- `npx ng build` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684ad5916b14832b8293a9e107bba8eb