### PR TITLE
Fix README duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+# Prana
 
-# Prana 1.0
+Backend (Django REST API) and frontend (Angular) for the Prana project.
 
 Prana is split into two parts:
 
@@ -10,7 +11,8 @@ Prana is split into two parts:
 
 ### Backend
 
-Install Python dependencies and run migrations:
+1. Create and activate a Python virtual environment.
+2. Install Python dependencies and run migrations:
 
 ```bash
 make reqinstall
@@ -20,7 +22,7 @@ make migrate
 Start the development server:
 
 ```bash
-python apiRest/manage.py runserver
+python apiRest/manage.py runserver --settings=core.settings.local
 ```
 
 You can also run `make runbe`.
@@ -42,45 +44,14 @@ ng serve
 
 Alternatively run `make runfe` from the project root.
 
-## Useful Make Targets
-
-- `reqinstall` – install Python requirements.
-- `feinstall` – install frontend dependencies.
-- `migrate` – apply Django migrations.
-- `runbe` – start the backend server.
-- `runfe` – start the frontend dev server.
-=======
-
-# Prana
-
-Backend and frontend for the Prana project.
-
 ## Environment variables
 
-The Django backend reads configuration from environment variables, typically via
-an `.env` file. Production settings look for the following variables:
+The Django backend reads configuration from environment variables, typically via an `.env` file. Production settings look for the following variables:
 
-- `ALLOWED_HOSTS` - comma separated list of allowed hosts. If not provided,
-  development defaults of `localhost,127.0.0.1` are used.
-- `CORS_ALLOWED_ORIGINS` - comma separated list of origins allowed by CORS. The
-  default is `http://localhost:4200` for development.
+- `ALLOWED_HOSTS` - comma separated list of allowed hosts. If not provided, development defaults of `localhost,127.0.0.1` are used.
+- `CORS_ALLOWED_ORIGINS` - comma separated list of origins allowed by CORS. The default is `http://localhost:4200` for development.
 
-=======
-# PranaV1.0
-
-## Installation
-
-1. Create and activate a Python virtual environment.
-2. Install the backend requirements:
-
-```bash
-pip install -r requirements.txt
-```
-
-## Environment variables
-
-Create a `.env` file inside `apiRest/core/` with at least the following
-variables:
+Create a `.env` file inside `apiRest/core/` with at least the following variables:
 
 ```ini
 SECRET_KEY=changeme
@@ -99,13 +70,9 @@ EMAIL_HOST_PASSWORD=password
 # DATABASE_PORT=3306
 ```
 
-Use `core.settings.local` for local development or
-`core.settings.production` for production. The local configuration uses a
-SQLite database and does not require the database variables.
+Use `core.settings.local` for local development or `core.settings.production` for production. The local configuration uses a SQLite database and does not require the database variables.
 
 ## Running migrations
-
-Run database migrations with:
 
 ```bash
 python apiRest/manage.py migrate --settings=core.settings.local
@@ -113,15 +80,11 @@ python apiRest/manage.py migrate --settings=core.settings.local
 
 ## Starting the development server
 
-Start the API using the local settings module:
-
 ```bash
 python apiRest/manage.py runserver --settings=core.settings.local
 ```
 
 ## Running tests
-
-Execute the Django tests with:
 
 ```bash
 python apiRest/manage.py test --settings=core.settings.local
@@ -129,9 +92,12 @@ python apiRest/manage.py test --settings=core.settings.local
 
 ## API documentation
 
-Swagger documentation is available once the server is running at
-`/swagger/`. The relevant routes are defined in
-[`core/urls.py`](apiRest/core/urls.py).
+Swagger documentation is available once the server is running at `/swagger/`. The relevant routes are defined in [`core/urls.py`](apiRest/core/urls.py).
 
+## Useful Make Targets
 
-
+- `reqinstall` – install Python requirements.
+- `feinstall` – install frontend dependencies.
+- `migrate` – apply Django migrations.
+- `runbe` – start the backend server.
+- `runfe` – start the frontend dev server.


### PR DESCRIPTION
## Summary
- remove duplicate sections in README
- keep single install guide and environment variable notes

## Testing
- `make test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684ae3d66da0832bb32185f46a0f4ea7