### PR TITLE
Replace prints with logging

### DIFF
--- a/apiRest/apps/appointments/api/serializers.py
+++ b/apiRest/apps/appointments/api/serializers.py
@@ -4,6 +4,9 @@ from django.db.models import Q
 from rest_framework import serializers
 from apps.usersProfile.models import DoctorProfile, PatientProfile, InsurancePlanDoctor, HealthInsurance, SpecialityBranch
 from apps.appointments.models import Appointment, PaymentMethod
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def set_duration(attrs: dict, instance: Appointment = None) -> dict:
@@ -671,7 +674,7 @@ class AppointmentSerializer(serializers.ModelSerializer):
                 patient_profile.insurances.add(particular_insurance)
                 patient_profile.save()
         except HealthInsurance.DoesNotExist:
-            print("La obra social 'Particular' no existe.")
+            logger.warning("La obra social 'Particular' no existe.")
 
         return appointment
 

--- a/apiRest/apps/users/api/serializers.py
+++ b/apiRest/apps/users/api/serializers.py
@@ -7,6 +7,9 @@ from rest_framework import serializers
 from apps.users.models import User
 from apps.usersProfile.models import PatientProfile, HealthInsurance
 from django.contrib.auth.hashers import check_password
+import logging
+
+logger = logging.getLogger(__name__)
 
 class UserShortSerializer(serializers.ModelSerializer):
     class Meta:
@@ -41,7 +44,7 @@ class UserAdminSerializer(serializers.ModelSerializer):
                 name__iexact='PARTICULAR')
             patient_profile.insurances.add(particular_insurance)
         except HealthInsurance.DoesNotExist:
-            print("La obra social 'Particular' no existe.")
+            logger.warning("La obra social 'Particular' no existe.")
 
         patient_profile.save()
 
@@ -118,7 +121,7 @@ class RegisterUserSerializer(serializers.ModelSerializer):
                 name__iexact='Particular')
             patient_profile.insurances.add(particular_insurance)
         except HealthInsurance.DoesNotExist:
-            print("La obra social 'Particular' no existe.")
+            logger.warning("La obra social 'Particular' no existe.")
 
         patient_profile.save()
 

--- a/apiRest/apps/users/api/views.py
+++ b/apiRest/apps/users/api/views.py
@@ -3,6 +3,9 @@ import string
 import secrets
 from django.contrib.auth import get_user_model
 from rest_framework import status
+import logging
+
+logger = logging.getLogger(__name__)
 from rest_framework.decorators import api_view, permission_classes
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
@@ -253,7 +256,7 @@ class LogoutAPI(generics.GenericAPIView):
             return response
 
         except Exception as e:
-            print(e)
+            logger.error(e)
             return Response({"message": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
@@ -308,7 +311,7 @@ class RegisterAPI(generics.GenericAPIView):
                 "message": "Usuario creado con éxito"
             }, status=status.HTTP_201_CREATED)
         else:
-            print(serializer.errors)
+            logger.error(serializer.errors)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def get_user_roles(self, user):


### PR DESCRIPTION
## Summary
- switch stray print statements to Python logging

## Testing
- `python apiRest/manage.py test --settings=core.settings.local` *(fails: SECRET_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684ae582db44832bb6424a0a8446ea21