### PR TITLE
Remove unused re_path import

### DIFF
--- a/apiRest/core/urls.py
+++ b/apiRest/core/urls.py
@@ -1,4 +1,3 @@
-from django.urls import re_path
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi


### PR DESCRIPTION
## Summary
- clean up unused `re_path` import

## Testing
- `python apiRest/manage.py test --settings=core.settings.local` *(fails: Incorrect timezone setting)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5852194832b9683b667c52e88b0