### PR TITLE
Fix Makefile migration cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ clean:
 
 # Target to clean up migrations (USE WITH CAUTION!)
 cleanmigrations:
-	del /s /q .\api\migrations\*.py
-	del /s /q .\api\migrations\*.pyc
+       rm -f ./api/migrations/*.py
+       rm -f ./api/migrations/*.pyc
 
 # Target to start a backend development server
 runbe:


### PR DESCRIPTION
## Summary
- fix `cleanmigrations` to use `rm` instead of Windows `del`

## Testing
- `pip install -r requirements.txt`
- `python apiRest/manage.py test --settings=core.settings.local` *(fails: SECRET_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5864f44832bb65362625cd694fa