### PR TITLE
Add root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# General operating system files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+*.env
+
+# Python caches and virtual environments
+__pycache__/
+*.py[cod]
+*$py.class
+.Python
+env/
+venv/
+ENV/
+.venv/
+env.bak/
+venv.bak/
+
+# Test and coverage outputs
+.cache/
+.mypy_cache/
+.pytest_cache/
+.coverage*
+
+# Package distribution
+build/
+dist/
+*.egg-info/
+
+# Logs
+*.log
+
+# Django specific
+*.sqlite3
+*.db
+local_settings.py
+media/
+staticfiles/
+core/deploy/prana.sock
+
+# Node / Angular
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.tmp/
+.angular/
+.angular/cache/
+out-tsc/
+coverage/
+


### PR DESCRIPTION
## Summary
- set up a project-wide `.gitignore` to exclude OS files, environment files, cache directories, logs and build outputs.

## Testing
- `python apiRest/manage.py test --settings=core.settings.local`

------
https://chatgpt.com/codex/tasks/task_e_684b08872ee4832b8f2cd143a655ccd0