### PR TITLE
Improve auth validations

### DIFF
--- a/Frontend/Prana/src/app/Modules/auth/components/login/login.component.ts
+++ b/Frontend/Prana/src/app/Modules/auth/components/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
 import { JwtResponse } from 'src/app/Models/user/jwtResponse.interface';
 import { LoginUser } from 'src/app/Models/user/loginUser.interface';
 import { AuthService } from 'src/app/Services/auth/auth.service';
@@ -37,7 +38,13 @@ export class LoginComponent implements OnInit , OnDestroy{
     if (this.loginForm.valid) {
       const user: LoginUser = this.loginForm.value;
 
-      this.loginSub = this.authService.login(user).subscribe();
+      this.errorMessage = '';
+      this.loginSub = this.authService.login(user).subscribe({
+        next: () => {},
+        error: (error: HttpErrorResponse) => {
+          this.errorMessage = error.error?.message || 'Usuario o Contrase\u00f1a incorrectos';
+        }
+      });
 
     }
   }

--- a/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.html
+++ b/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.html
@@ -49,6 +49,7 @@
   
       <mat-form-field appearance="outline">
         <input matInput placeholder="Teléfono" type="number" formControlName="phone">
+        <mat-error *ngIf="phone?.errors?.['pattern']">Ingrese un teléfono válido.</mat-error>
       </mat-form-field >
 
       <mat-form-field appearance="outline">

--- a/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.ts
+++ b/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.ts
@@ -10,7 +10,7 @@ import { DialogService } from 'src/app/Services/dialog/dialog.service';
   templateUrl: './singin.component.html',
   styleUrls: ['./singin.component.css']
 })
-export class SinginComponent {
+export class SinginComponent implements OnInit {
   registerForm!: FormGroup;
 
   constructor(private fb: FormBuilder, private router: Router,private authService: AuthService, private dialogService: DialogService) {
@@ -23,7 +23,7 @@ export class SinginComponent {
       name: ['', [Validators.required, Validators.pattern("^[a-zA-Z0-9+\-ñ ]*$"),]],
       last_name: ['', [Validators.required,Validators.pattern("^[a-zA-Z0-9+\-ñ ]*$")]],
       email: ['', [Validators.required, Validators.pattern('^[a-zA-Z0-9._+-ñ]+@[a-zA-Z0-9_.-]+\.[a-zA-Z]{2,4}$')]],
-      phone: [''],
+      phone: ['', [Validators.pattern('^[0-9]*$')]],
       password: ['', [Validators.required, Validators.minLength(8)]]
       
     });
@@ -42,6 +42,10 @@ export class SinginComponent {
 
   get email() {
     return this.registerForm.get('email');
+  }
+
+  get phone() {
+    return this.registerForm.get('phone');
   }
   get password() {
     return this.registerForm.get('password');

--- a/Frontend/Prana/src/app/Services/auth/auth.service.ts
+++ b/Frontend/Prana/src/app/Services/auth/auth.service.ts
@@ -59,9 +59,9 @@ export class AuthService {
       .post<JwtResponse>(this.loginUrl, user, { withCredentials: true })
       .pipe(
         tap((response) => this.handleLogin(response)),
-        catchError((error) => {
+        catchError((error: HttpErrorResponse) => {
           this.dialogService.showErrorDialog(error.error?.message || 'Usuario o Contraseña incorrectos');
-          return throwError(() => new Error('Error al iniciar sesión'));
+          return throwError(() => error);
         })
       );
   }


### PR DESCRIPTION
## Summary
- enhance login error handling to show messages
- add phone validation on sign up and expose getter
- implement OnInit in sign up component
- expose error output from AuthService

## Testing
- `npm test --silent` *(fails: ng not found)*
- `python manage.py test --settings=core.settings.local` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684b1834f484832bbbe22a5e2c86744e