### PR TITLE
Fix registration numeric password error

### DIFF
--- a/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.html
+++ b/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.html
@@ -56,6 +56,8 @@
         <mat-error *ngIf="password?.invalid && (password?.dirty || password?.touched)">
           <span *ngIf="password?.errors?.['required']">La contraseña es requerida.</span>
           <span *ngIf="password?.errors?.['minlength']">La contraseña debe tener al menos 8 caracteres.</span>
+          <span *ngIf="password?.errors?.['pattern']">La contraseña no puede contener solo números.</span>
+          <span *ngIf="password?.errors?.['passwordNumeric']">{{ password?.errors?.['passwordNumeric'] }}</span>
         </mat-error>
       </mat-form-field>
   

--- a/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.ts
+++ b/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.ts
@@ -24,7 +24,11 @@ export class SinginComponent {
       last_name: ['', [Validators.required,Validators.pattern("^[a-zA-Z0-9+\-ñ ]*$")]],
       email: ['', [Validators.required, Validators.pattern('^[a-zA-Z0-9._+-ñ]+@[a-zA-Z0-9_.-]+\.[a-zA-Z]{2,4}$')]],
       phone: [''],
-      password: ['', [Validators.required, Validators.minLength(8)]]
+      password: ['', [
+        Validators.required,
+        Validators.minLength(8),
+        Validators.pattern('^(?!\\d+$).+')
+      ]]
       
     });
   }
@@ -60,16 +64,22 @@ export class SinginComponent {
           this.router.navigate(['/Dashboard/accounts/myaccount']);
         },
         error: (error) => {
-          
-          if (error.error.message.includes("DNI")) {
-            // Manejar error específico de DN
-            
-            this.registerForm.controls['dni'].setErrors({ 'dniExists': true });
+
+          if (error.error?.message?.includes("DNI")) {
+            // Manejar error específico de DNI
+            this.registerForm.controls['dni'].setErrors({ dniExists: true });
           }
-          if (error.error.message.includes("email")) {
+
+          if (error.error?.message?.includes("email")) {
             // Manejar error específico de email
-            
-            this.registerForm.controls['email'].setErrors({ 'emailExists': true });
+            this.registerForm.controls['email'].setErrors({ emailExists: true });
+          }
+
+          if (error.error?.password) {
+            const msg = Array.isArray(error.error.password)
+              ? error.error.password[0]
+              : error.error.password;
+            this.registerForm.controls['password'].setErrors({ passwordNumeric: msg });
           }
         }
       });


### PR DESCRIPTION
## Summary
- show password error message if it is numeric only
- add regex pattern to prevent all-digit password
- surface backend password error to the user

## Testing
- `pip install -r requirements.txt`
- `python apiRest/manage.py test --settings=core.settings.local` *(fails: SECRET_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684b1a082d38832b870d8f6b197b6667