### PR TITLE
Handle password validation errors on signup

### DIFF
--- a/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.html
+++ b/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.html
@@ -57,6 +57,7 @@
         <mat-error *ngIf="password?.invalid && (password?.dirty || password?.touched)">
           <span *ngIf="password?.errors?.['required']">La contraseña es requerida.</span>
           <span *ngIf="password?.errors?.['minlength']">La contraseña debe tener al menos 8 caracteres.</span>
+          <span *ngIf="password?.errors?.['passwordInvalid']">{{password?.errors?.['passwordInvalid']}}</span>
         </mat-error>
       </mat-form-field>
   

--- a/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.ts
+++ b/Frontend/Prana/src/app/Modules/auth/components/singin/singin.component.ts
@@ -64,16 +64,19 @@ export class SinginComponent implements OnInit {
           this.router.navigate(['/Dashboard/accounts/myaccount']);
         },
         error: (error) => {
-          
-          if (error.error.message.includes("DNI")) {
-            // Manejar error específico de DN
-            
-            this.registerForm.controls['dni'].setErrors({ 'dniExists': true });
+          if (error.error.message && error.error.message.includes("DNI")) {
+            // Manejar error específico de DNI
+            this.registerForm.controls['dni'].setErrors({ dniExists: true });
           }
-          if (error.error.message.includes("email")) {
+          if (error.error.message && error.error.message.includes("email")) {
             // Manejar error específico de email
-            
-            this.registerForm.controls['email'].setErrors({ 'emailExists': true });
+            this.registerForm.controls['email'].setErrors({ emailExists: true });
+          }
+          if (error.error.password) {
+            const backendMessage = Array.isArray(error.error.password)
+              ? error.error.password[0]
+              : error.error.password;
+            this.registerForm.controls['password'].setErrors({ passwordInvalid: backendMessage });
           }
         }
       });


### PR DESCRIPTION
## Summary
- handle backend password errors on signup
- display numeric-password error to the user

## Testing
- `npm test` *(fails: ng not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b1bc6bdbc832ba34da5177bac31cd